### PR TITLE
Push (some) metrics to cloudwatch

### DIFF
--- a/automate_es_backends.tf
+++ b/automate_es_backends.tf
@@ -24,6 +24,7 @@ resource "aws_instance" "es_backend" {
     Name      = "${format("${var.automate_tag}_${random_id.automate_instance_id.hex}_esbackend_%02d", count.index + 1)}"
     X-Dept    = "${var.tag_dept}"
     X-Contact = "${var.tag_contact}"
+    TestId    = "${var.tag_test_id}"
   }
 
   provisioner "remote-exec" {
@@ -52,7 +53,7 @@ resource "aws_instance" "es_backend" {
     environment             = "_default"
     node_name               = "es-backend${self.id}-${count.index + 1}"
     fetch_chef_certificates = true
-    run_list                = ["${var.automate_es_recipe}"]
+    run_list                = ["${var.automate_es_recipe}", "collect_metrics::es_backend"]
     server_url              = "https://${aws_instance.chef_server.public_dns}/organizations/delivery"
     user_name               = "delivery-validator"
     user_key                = "${data.template_file.delivery_validator.rendered}"

--- a/automate_server.tf
+++ b/automate_server.tf
@@ -33,6 +33,7 @@ resource "aws_instance" "chef_automate" {
     Name      = "${format("${var.automate_tag}_${random_id.automate_instance_id.hex}_chef_automate_%02d", count.index + 1)}"
     X-Dept    = "${var.tag_dept}"
     X-Contact = "${var.tag_contact}"
+    TestId    = "${var.tag_test_id}"
   }
 
   # Set hostname in separate connection.
@@ -77,7 +78,7 @@ resource "aws_instance" "chef_automate" {
 
     environment             = "_default"
     fetch_chef_certificates = true
-    run_list                = ["chef-services::delivery"]
+    run_list                = ["chef-services::delivery", "collect_metrics::automate"]
     node_name               = "${aws_instance.chef_automate.public_dns}"
     server_url              = "https://${aws_instance.chef_server.public_dns}/organizations/delivery"
     user_name               = "delivery-validator"

--- a/chef_load_server.tf
+++ b/chef_load_server.tf
@@ -41,6 +41,7 @@ resource "aws_instance" "chef_load" {
     Name      = "${format("${var.automate_tag}_chef_load_%02d_${random_id.automate_instance_id.hex}", count.index + 1)}"
     X-Dept    = "${var.tag_dept}"
     X-Contact = "${var.tag_contact}"
+    TestId    = "${var.tag_test_id}"
   }
 
   # Set hostname in separate connection.

--- a/chef_server.tf
+++ b/chef_server.tf
@@ -41,6 +41,7 @@ resource "aws_instance" "chef_server" {
     Name      = "${format("${var.automate_tag}_${random_id.automate_instance_id.hex}_chef_server_%02d", count.index + 1)}"
     X-Dept    = "${var.tag_dept}"
     X-Contact = "${var.tag_contact}"
+    TestId    = "${var.tag_test_id}"
   }
 
   # Set hostname in separate connection.

--- a/files/installer.sh
+++ b/files/installer.sh
@@ -91,7 +91,7 @@ source 'https://supermarket.chef.io'
 
 cookbook 'chef-services', git: 'https://github.com/itmustbejj/chef-services.git', branch: 'deltron-changes'
 cookbook 'chef-ingredient', git: 'https://github.com/itmustbejj/chef-ingredient', branch: 'debug-branch'
-cookbook 'collect_metrics', git: 'https://github.com/yzl/collect_metrics.git', branch: 'yzl/iterate'
+cookbook 'collect_metrics', git: 'https://github.com/yzl/collect_metrics.git'
 cookbook 'elasticsearch', git: 'https://github.com/itmustbejj/cookbook-elasticsearch', branch: '2.x.x'
 cookbook 'java'
 cookbook 'sysctl'

--- a/files/installer.sh
+++ b/files/installer.sh
@@ -91,6 +91,7 @@ source 'https://supermarket.chef.io'
 
 cookbook 'chef-services', git: 'https://github.com/itmustbejj/chef-services.git', branch: 'deltron-changes'
 cookbook 'chef-ingredient', git: 'https://github.com/itmustbejj/chef-ingredient', branch: 'debug-branch'
+cookbook 'collect_metrics', git: 'https://github.com/yzl/collect_metrics.git', branch: 'yzl/iterate'
 cookbook 'elasticsearch', git: 'https://github.com/itmustbejj/cookbook-elasticsearch', branch: '2.x.x'
 cookbook 'java'
 cookbook 'sysctl'

--- a/main.tf
+++ b/main.tf
@@ -74,6 +74,10 @@ variable "tag_contact" {
   default = "irving"
 }
 
+variable "tag_test_id" {
+  default = "automate_scale_test"
+}
+
 # Basic AWS info
 provider "aws" {
   region  = "${var.aws_region}"

--- a/main.tf
+++ b/main.tf
@@ -140,6 +140,6 @@ EOF
 }
 
 resource "aws_iam_instance_profile" "cloudwatch_metrics_instance_profile" {
-  name = "cw_metrics_instance_profile_${random_id.automate_instance_id.hex}"
+  name = "cloudwatch_metrics_instance_profile_${random_id.automate_instance_id.hex}"
   role = "${aws_iam_role.cloudwatch_metrics_role.name}"
 }

--- a/main.tf
+++ b/main.tf
@@ -125,7 +125,16 @@ resource "aws_iam_role_policy" "cloudwatch_metrics_policy" {
   "Version": "2012-10-17",
   "Statement": [
     {
-      "Sid": "Stmt1499048077909",
+      "Sid": "Stmt1499208295508",
+      "Action": [
+        "ec2:DescribeTags",
+        "ec2:DescribeInstances"
+      ],
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Sid": "Stmt1499208317792",
       "Action": [
         "cloudwatch:ListMetrics",
         "cloudwatch:PutMetricData",


### PR DESCRIPTION
* Update policy to allow ec2 describe-instances and describe-tags.
* Added TestId tag and plumbed it through as a dimension for our cloudwatch metrics.
* Pull in yzl/collect_metrics cookbook to install metrics scripts and set up cron jobs to run them.